### PR TITLE
Replacing the theme's default HTML title

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ DESIGNED & DEVELOPED by FREEHTML5.CO
 	<head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>Work &mdash; A free Responsive HTML5 Template by FREEHTML5.CO</title>
+	<title>Rebooting the Web-Of-Trust</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="Free HTML5 Template by FREEHTML5.CO" />
   	<meta name="keywords" content="free html5, free template, free bootstrap, html5, css3, mobile first, responsive" />


### PR DESCRIPTION
The HTML title of the page was still the theme default's one. Which is unrelated to the actual content of the page, and can cause confusion particularly when sharing the page.